### PR TITLE
Don't save file over itself when dealing with a local file

### DIFF
--- a/browscap/Browscap.php
+++ b/browscap/Browscap.php
@@ -462,11 +462,12 @@ class Browscap
 			$subject = trim($subject);
 			$content .= preg_replace($pattern, '$1="$2"', $subject) . "\n";
 		}
-
-		if (!file_put_contents($path, $content)) {
-			throw new Browscap_Exception("Could not write .ini content to $path");
+		
+		if ($url != $path) {
+			if (!file_put_contents($path, $content)) {
+				throw new Browscap_Exception("Could not write .ini content to $path");
+			}
 		}
-
 		return true;
 	}
 


### PR DESCRIPTION
Just to prevent notices when the location of ini file is not writable.
