### PR TITLE
Add user agent keyword to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "garetjax/phpbrowscap",
     "type": "library",
     "description": "Standalone replacement for php's native get_browser() function",
-    "keywords": ["get_browser", "browser", "capabilities"],
+    "keywords": ["get_browser", "browser", "capabilities", "user agent"],
     "homepage": "http://github.com/GaretJax/phpbrowscap",
     "license": "MIT License",
     "authors": [


### PR DESCRIPTION
When searching for a library like this, I was thinking in terms of `user agents`, rather than `browsers`, so I think they keyword should be added.
