### PR TITLE
PHP Exception Namespace

### DIFF
--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -687,6 +687,6 @@ class Browscap
  * @version    1.0
  * @license    http://www.opensource.org/licenses/MIT MIT License
  * @link       https://github.com/GaretJax/phpbrowscap/*/
-class Browscap_Exception extends Exception
+class Browscap_Exception extends \Exception
 {}
 


### PR DESCRIPTION
Hi, I just checked out your project for use in a Symfony project I'm working on. I noticed that you're missing a backslash @line 690 to extend a native PHP Exception. Not much of a contribution I know - this is my first fork/pull-request :)
