### PR TITLE
Add an action method to Browscap

### DIFF
--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -516,6 +516,32 @@ class Browscap
     }
 
     /**
+     * Execute the callback passed to it depending on the given rules
+     *
+     * @param array    rules
+     * @param callback callback
+     * @param operator string
+     *
+     * @return void
+     */
+    public function action($rules, $callback, $operator = '>')
+    {
+        if (is_string($callback) || !is_callable($callback)) {
+            throw new Exception("The second argument you passed isn't a callback!");
+        }
+
+        $browser = $this->getBrowser();
+
+        $platform = array_key_exists($browser->Platform, $rules) ? $browser->Platform : 'default';
+
+        if (array_key_exists($browser->Browser, $rules[$platform])) {
+            if (version_compare($rules[$platform][$browser->Browser], $browser->Version, $operator)) {
+                return call_user_func($callback, $browser);
+            }
+        }
+    }
+
+    /**
      * Loads the cache into object's properties
      *
      * @return void

--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -524,13 +524,13 @@ class Browscap
      *
      * @return void
      */
-    public function action($rules, $callback, $operator = '>')
+    public function action($rules, $callback, $operator = '>', $userAgent = null)
     {
         if (is_string($callback) || !is_callable($callback)) {
             throw new Exception("The second argument you passed isn't a callback!");
         }
 
-        $browser = $this->getBrowser();
+        $browser = $this->getBrowser($userAgent);
 
         $platform = array_key_exists($browser->Platform, $rules) ? $browser->Platform : 'default';
 

--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -31,7 +31,8 @@ use \Exception as BaseException;
  *
  * @package    Browscap
  * @author     Jonathan Stoppani <jonathan@stoppani.name>
- * @author     Vítor Brandão <noisebleed@noiselabs.org>
+ * @author     Vítor Brandão     <noisebleed@noiselabs.org>
+ * @author     Samy Dindane      <samy@dindane.com>
  * @copyright  Copyright (c) 2006-2012 Jonathan Stoppani
  * @version    1.0
  * @license    http://www.opensource.org/licenses/MIT MIT License

--- a/tests/phpbrowscap/BrowscapTest.php
+++ b/tests/phpbrowscap/BrowscapTest.php
@@ -31,6 +31,7 @@ use phpbrowscap\Browscap;
  *
  * @package    Browscap
  * @author     Vítor Brandão <noisebleed@noiselabs.org>
+ * @author     Samy Dindane  <samy@dindane.com>
  * @copyright  Copyright (c) 2006-2012 Jonathan Stoppani
  * @version    1.0
  * @license    http://www.opensource.org/licenses/MIT MIT License

--- a/tests/phpbrowscap/BrowscapTest.php
+++ b/tests/phpbrowscap/BrowscapTest.php
@@ -98,6 +98,32 @@ class BrowscapTest extends TestCase
 
         $this->assertTrue(is_resource($resource));
     }
+
+    public function testAction()
+    {
+        $browscap = new BrowscapForTest($this->createCacheDir());
+
+        $callback = function() { return true; };
+        $rules    = array(
+            'WinXP'   => array(
+              'Chrome'  => '20.2',
+              'Safari'  => '5.0',
+            ),
+            'default' => array(
+              'Chrome'  => '4.0',
+              'IE'      => '7',
+            )
+        );
+
+        $chromeWinUserAgent    = 'Mozilla/5.0 (Windows NT 5.1) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1089.0 Safari/536.6';
+        $firefoxLinuxUserAgent = 'Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0';
+
+        $this->assertTrue($browscap->action($rules, $callback, '>', $chromeWinUserAgent));
+        unset($rules['WinXP']);
+        $this->assertNull($browscap->action($rules, $callback, '>', $chromeWinUserAgent));
+        $this->assertTrue($browscap->action($rules, $callback, '<', $chromeWinUserAgent));
+        $this->assertNull($browscap->action($rules, $callback, '>', $firefoxLinuxUserAgent));
+    }
 }
 
 class BrowscapForTest extends Browscap

--- a/tests/phpbrowscap/TestCase.php
+++ b/tests/phpbrowscap/TestCase.php
@@ -31,6 +31,7 @@ use phpbrowscap\Browscap;
  *
  * @package    Browscap
  * @author     Vítor Brandão <noisebleed@noiselabs.org>
+ * @author     Samy Dindane  <samy@dindane.com>
  * @copyright  Copyright (c) 2006-2012 Jonathan Stoppani
  * @version    1.0
  * @license    http://www.opensource.org/licenses/MIT MIT License

--- a/tests/phpbrowscap/TestCase.php
+++ b/tests/phpbrowscap/TestCase.php
@@ -69,6 +69,8 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function removeCacheDir()
     {
         if (isset($this->cacheDir) && is_dir($this->cacheDir)) {
+            @unlink($this->cacheDir.'/browscap.ini');
+            @unlink($this->cacheDir.'/cache.php');
             if (false === @rmdir($this->cacheDir)) {
                 throw new \RuntimeException(sprintf('Unable to remove the "%s" directory', $this->cacheDir));
             }


### PR DESCRIPTION
Hi, 

I added a method called `action` (the name can be improved), that executes a specific action depending on the rules passed to it. 

An example would be more explanatory: 

Let's say you want to redirect all the visitors whose 
- Chrome version is older than 15 on Linux
- Chrome version is older than 20 on all the other platforms
- Firefox version is older than 10

You'd then just create an array containing these rules: 

```
$rules = array(
    'Linux' => array(
        'Chrome' => 15,
    ),
    'default' => array(
        'Chrome' => 20,
        'Firefox'   => 10,
    ),
);
```

And then specify, in a callback, what you want to do (redirecting in this case) if these rules aren't followed:

```
$callback = function() { header('Location: /update-your-browser'); };
```

Now all what you have to do is to pass these information to `action()`:

```
$bc->action($rules, $callback);
```

You can also ask for the callback to be called when the rules _are met_ by passing a _higher than_ operator as a third parameter: `$bc->action($rules, $callback, '>');`.

I find this very useful, since I, myself, needed to do different things depending on the user's browser, and I think it would be helpful to other people, especially combined with the great information this library provides. 

I'll update the documentation when this PR will be merged. 

Cheers,
Samy
