### PR TITLE
Change the duplicate check from single numbers to numbers with dots

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,8 @@
+# .coveralls.yml configuration
+
+service_name: travis-ci # travis-ci or travis-pro
+
+# for php-coveralls
+src_dir: src
+coverage_clover: build/logs/clover.xml
+json_path: build/logs/coveralls-upload.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.settings
 /.buildpath
 /.project
+/vendor
+/tests/output

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 build/
 /.project
 /tests/output
+result.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 /.settings
 /.buildpath
+vendor/
+build/
 /.project
-/vendor
 /tests/output

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,84 @@
+before_commands:
+    - "composer install --prefer-source"
+
+tools:
+    # Code Coverage
+    php_code_coverage:
+        enabled:              true
+        test_command:         phpunit
+        filter:
+            excluded_paths:
+                - 'vendor/*'
+                - 'tests/*'
+
+
+    # Code Sniffer
+    php_code_sniffer:
+        enabled:              true
+        command:              phpcs
+        config:
+            standard:         PSR2
+        filter:
+            excluded_paths:
+                - 'vendor/*'
+
+
+    # Copy/Paste Detector
+    php_cpd:
+        enabled:              true
+        command:              phpcpd
+        excluded_dirs:
+            - 'vendor'
+
+
+    # PHP CS Fixer (http://http://cs.sensiolabs.org/).
+    php_cs_fixer:
+        enabled:              true
+        command:              php-cs-fixer
+        config:
+            level:            psr2
+        filter:
+            excluded_paths:
+                - 'vendor/*'
+
+
+    # Analyzes the size and structure of a PHP project.
+    php_loc:
+        enabled:              true
+        command:              phploc
+        excluded_dirs:
+            - vendor
+
+
+    # PHP Mess Detector (http://phpmd.org).
+    php_mess_detector:
+        enabled:              true
+        command:              phpmd
+        config:
+            rulesets:
+                - codesize
+                - unusedcode
+                - naming
+                - design
+                - controversial
+        filter:
+            excluded_paths:
+                - 'vendor/*'
+
+
+    # Analyzes the size and structure of a PHP project.
+    php_pdepend:
+        enabled:              true
+        command:              pdepend
+        excluded_dirs:
+            - vendor
+
+    # Runs Scrutinizer's PHP Analyzer Tool
+    php_analyzer:
+        enabled:              true
+        filter:
+            excluded_paths:
+              - 'vendor/*'
+
+    # Security Advisory Checker
+    sensiolabs_security_checker: true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -42,7 +42,7 @@ tools:
 
     # PHP CS Fixer (http://http://cs.sensiolabs.org/).
     php_cs_fixer:
-        enabled:              true
+        enabled:              false
         command:              php-cs-fixer
         config:
             level:            psr2

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,7 +4,7 @@ before_commands:
 tools:
     # Code Coverage
     php_code_coverage:
-        enabled:              true
+        enabled:              false
         test_command:         phpunit
         filter:
             excluded_paths:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,6 +3,15 @@ before_commands:
 
 tools:
     # Code Coverage
+    external_code_coverage:
+        enabled: true
+        timeout: 300
+        filter:
+            excluded_paths:
+                - 'vendor/*'
+                - 'tests/*'
+
+
     php_code_coverage:
         enabled:              false
         test_command:         phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script:
 
 after_script:
   - php vendor/bin/coveralls -v
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
+  - 5.5
+  - 5.4
+  - 5.3
 
 before_script:
   - composer self-update
   - composer install --dev --prefer-source
   - php vendor/autoload.php
-  - cp phpunit.xml.dist tests/phpunit.xml
 
 script:
-  - phpunit --configuration tests/phpunit.xml --coverage-text --colors --verbose
+  - mkdir -p build/logs
+  - phpunit --configuration travis.phpunit.xml.dist --colors --verbose
+
+after_script:
+  - php vendor/bin/coveralls -v
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,16 @@ language: php
 php:
     - 5.3
     - 5.4
+    - 5.5
+
+before_script:
+  - composer self-update
+  - composer install --dev --prefer-source
+  - php vendor/autoload.php
+  - cp phpunit.xml.dist tests/phpunit.xml
+
+script:
+  - phpunit --configuration tests/phpunit.xml --coverage-text --colors --verbose
+
+notifications:
+  email: false

--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,19 @@ Browser Capabilities PHP Project
 
 _Hacking around with PHP to have a better solution than `get_browser()`_
 
-[![Build Status](https://secure.travis-ci.org/GaretJax/phpbrowscap.png?branch=master)](http://travis-ci.org/GaretJax/phpbrowscap)
+[![Build Status](https://travis-ci.org/GaretJax/phpbrowscap.png?branch=master)](https://travis-ci.org/GaretJax/phpbrowscap)
+[![Dependency Status](https://depending.in/GaretJax/phpbrowscap.png)](http://depending.in/GaretJax/phpbrowscap)
+
+[![Coverage Status](https://coveralls.io/repos/GaretJax/phpbrowscap/badge.png?branch=master)](https://coveralls.io/r/GaretJax/phpbrowscap?branch=master)
+[![Dependency Status](https://www.versioneye.com/user/projects/52a7612e632bac3d03000027/badge.png)](https://www.versioneye.com/user/projects/52a7612e632bac3d03000027)
+
+[![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/GaretJax/phpbrowscap/badges/quality-score.png?s=fc8a4eebfebc543ba625cca857685b65973ed416)](https://scrutinizer-ci.com/g/GaretJax/phpbrowscap/) 
+[![Code Coverage](https://scrutinizer-ci.com/g/GaretJax/phpbrowscap/badges/coverage.png?s=0318faef2d8697e53d768a2e8af60ff133631c27)](https://scrutinizer-ci.com/g/GaretJax/phpbrowscap/)
+
+[![Latest Stable Version](https://poser.pugx.org/GaretJax/phpbrowscap/v/stable.png)](https://packagist.org/packages/GaretJax/phpbrowscap)
+[![Latest Unstable Version](https://poser.pugx.org/GaretJax/phpbrowscap/v/unstable.png)](https://packagist.org/packages/GaretJax/phpbrowscap)
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/GaretJax/phpbrowscap/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
 
 Changes (new version - 2.0)

--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,7 @@ _Hacking around with PHP to have a better solution than `get_browser()`_
 [![Latest Unstable Version](https://poser.pugx.org/GaretJax/phpbrowscap/v/unstable.png)](https://packagist.org/packages/GaretJax/phpbrowscap)
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/GaretJax/phpbrowscap/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+[![Total views](https://sourcegraph.com/api/repos/github.com/GaretJax/phpbrowscap/counters/views.png)](https://sourcegraph.com/github.com/GaretJax/phpbrowscap)
 
 
 Changes (new version - 2.0)

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "mimmi20/file-loader": "1.1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
         "ext-xdebug": "*",
         "mikey179/vfsStream": "1.3.*@dev",
         "satooshi/php-coveralls": "dev-master",
-        "phpunit/phpcov": "2.0.*@dev"
+        "phpunit/phpcov": "2.0.*@dev",
+        "squizlabs/php_codesniffer": "dev-master",
+        "phpmd/phpmd": "dev-master",
+        "sebastian/phpcpd": "2.0.*@dev",
+        "pdepend/pdepend": "dev-master"
     },
     "suggest": {
         "ext-curl": "to use curl requests to get the browscap.ini file"

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,16 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "*",
+        "ext-xdebug": "*",
+        "mikey179/vfsStream": "1.3.*@dev",
+        "satooshi/php-coveralls": "dev-master",
+        "phpunit/phpcov": "2.0.*@dev"
+    },
+    "suggest": {
+        "ext-curl": "to use curl requests to get the browscap.ini file"
+    },
     "autoload": {
         "psr-0": { "phpbrowscap": "src/" }
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php"
+<phpunit bootstrap="./bootstrap.php"
          verbose="false"
          stopOnError="false"
          stopOnFailure="false"
@@ -8,18 +8,13 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         colors="true"
+         colors="false"
          forceCoversAnnotation="false"
          strict="false"
          processIsolation="false">
     <testsuites>
         <testsuite name="phpbrowscap Test Suite">
-            <directory>tests/phpbrowscap/</directory>
+            <directory>./phpbrowscap/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/phpbrowscap/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./bootstrap.php"
+<phpunit bootstrap="tests/bootstrap.php"
          verbose="false"
          stopOnError="false"
          stopOnFailure="false"
@@ -8,13 +8,18 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         colors="false"
+         colors="true"
          forceCoversAnnotation="false"
          strict="false"
          processIsolation="false">
     <testsuites>
         <testsuite name="phpbrowscap Test Suite">
-            <directory>./phpbrowscap/</directory>
+            <directory>tests/phpbrowscap/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/phpbrowscap/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./bootstrap.php"
+         verbose="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         colors="false"
+         forceCoversAnnotation="false"
+         strict="false"
+         processIsolation="false">
     <testsuites>
         <testsuite name="phpbrowscap Test Suite">
-            <directory>tests/phpbrowscap/</directory>
+            <directory>./phpbrowscap/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/phpbrowscap/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -44,7 +44,7 @@ class Browscap
      * Current version of the class.
      */
     const VERSION = '2.0b';
-    
+
     const CACHE_FILE_VERSION = '2.0b';
 
     /**
@@ -68,7 +68,7 @@ class Browscap
      */
     const REGEX_DELIMITER = '@';
     const REGEX_MODIFIERS = 'i';
-    
+
     const COMPRESSION_PATTERN_START = '@';
     const COMPRESSION_PATTERN_DELIMITER = '|';
 
@@ -76,7 +76,7 @@ class Browscap
      * The values to quote in the ini file
      */
     const VALUES_TO_QUOTE = 'Browser|Parent';
-    
+
     const BROWSCAP_VERSION_KEY = 'GJK_Browscap_Version';
 
     /**
@@ -97,7 +97,7 @@ class Browscap
      * $doAutoUpdate: Flag to disable the automatic interval based update.
      * $updateMethod: The method to use to update the file, has to be a value of
      *                an UPDATE_* constant, null or false.
-     *                
+     *
      * The default source file type is changed from normal to full. The performance difference
      * is MINIMAL, so there is no reason to use the standard file whatsoever. Either go for light,
      * which is blazing fast, or get the full one. (note: light version doesn't work, a fix is on its way)
@@ -242,7 +242,7 @@ class Browscap
 
         $this->cacheDir .= DIRECTORY_SEPARATOR;
     }
-    
+
     public function getSourceVersion()
     {
       return $this->_source_version;
@@ -250,7 +250,7 @@ class Browscap
 
     /**
      * XXX parse
-     * 
+     *
      * Gets the information about the browser by User Agent
      *
      * @param string $user_agent  the user agent string
@@ -272,9 +272,9 @@ class Browscap
             } else {
                 $interval = 0;
             }
-            
+
             $update_cache = true;
-            
+
             if (file_exists($cache_file) && file_exists($ini_file) && ($interval <= $this->updateInterval))
             {
               if ($this->_loadCache($cache_file))
@@ -282,7 +282,7 @@ class Browscap
                 $update_cache = false;
               }
             }
-            
+
             if ($update_cache) {
                 try {
                     $this->updateCache();
@@ -299,13 +299,13 @@ class Browscap
                         throw $e;
                     }
                 }
-                
+
                 if (!$this->_loadCache($cache_file))
                 {
                   throw new Exception("Cannot load this cache version - the cache format is not compatible.");
                 }
             }
-            
+
         }
 
         // Automatically detect the useragent
@@ -481,7 +481,7 @@ class Browscap
 
     /**
      * XXX save
-     * 
+     *
      * Parses the ini file and updates the cache files
      *
      * @return bool whether the file was correctly written to the disk
@@ -505,14 +505,14 @@ class Browscap
         } else {
             $browsers = parse_ini_file($ini_path, true);
         }
-        
+
         $this->_source_version = $browsers[self::BROWSCAP_VERSION_KEY]['Version'];
         unset($browsers[self::BROWSCAP_VERSION_KEY]);
-        
+
         unset($browsers['DefaultProperties']['RenderingEngine_Description']);
 
         $this->_properties = array_keys($browsers['DefaultProperties']);
-        
+
         array_unshift(
             $this->_properties,
             'browser_name',
@@ -520,9 +520,9 @@ class Browscap
             'browser_name_pattern',
             'Parent'
         );
-        
+
         $tmp_user_agents = array_keys($browsers);
-        
+
 
         usort($tmp_user_agents, array($this, 'compareBcStrings'));
 
@@ -532,27 +532,27 @@ class Browscap
         $tmp_patterns = array();
 
         foreach ($tmp_user_agents as $i => $user_agent) {
-          
+
             if (empty($browsers[$user_agent]['Comment']) || strpos($user_agent, '*') !== false || strpos($user_agent, '?') !== false)
             {
                 $pattern = $this->_pregQuote($user_agent);
-                
+
                 // undo quoting stars and dots
                 $temp_pattern = str_replace(array('.*', '.', '\?'), array('*', '?', '.'), $pattern);
-                
+
                 $matches_count = preg_match_all('@([\d\.]*[\d]+\.[\d]+)@', $temp_pattern, $matches);
-  
+
                 if (!$matches_count) {
                     $tmp_patterns[$pattern] = $i;
                 } else {
                     $compressed_pattern = preg_replace('@([\d\.]*[\d]+\.[\d]+)@', '([\d\.]*[\d]+\.[\d]+)', $temp_pattern);
                     // redo quoting stars and dots
                     $compressed_pattern = str_replace(array('.', '?', '*', '([\\d\\\\.].*[\\d]+\\\\.[\\d]+)'), array('\.', '.', '.*', '([\d\.]*[\d]+\.[\d]+)'), $compressed_pattern);
-                    
+
                     if (!isset($tmp_patterns[$compressed_pattern])) {
                         $tmp_patterns[$compressed_pattern] = array('first' => $pattern);
                     }
-  
+
                     $tmp_patterns[$compressed_pattern][$i] = $matches[0];
                 }
             }
@@ -570,11 +570,11 @@ class Browscap
                 {
                   continue;
                 }
-                
+
                 $key = $properties_keys[$key];
                 $browser[$key] = $value;
             }
-            
+
 
             $this->_browsers[] = $browser;
         }
@@ -593,7 +593,7 @@ class Browscap
             $this->_patterns[$pattern] = $pattern_data;
           }
         }
-        
+
         // Save the keys lowercased if needed
         if ($this->lowercase) {
             $this->_properties = array_map('strtolower', $this->_properties);
@@ -605,97 +605,97 @@ class Browscap
         // Save and return
         return (bool) file_put_contents($cache_path, $cache, LOCK_EX);
     }
-    
+
     protected function compareBcStrings($a, $b)
     {
       $a_len = strlen($a);
       $b_len = strlen($b);
-      
+
       if ($a_len > $b_len) return -1;
       if ($a_len < $b_len) return 1;
-      
+
       $a_len = strlen(str_replace(array('*', '?'), '', $a));
       $b_len = strlen(str_replace(array('*', '?'), '', $b));
-      
+
       if ($a_len > $b_len) return -1;
       if ($a_len < $b_len) return 1;
-      
+
       return 0;
     }
-    
+
     /**
      * That looks complicated...
-     * 
+     *
      * All numbers are taken out into $matches, so we check if any of those numbers are identical
      * in all the $matches and if they are we restore them to the $pattern, removing from the $matches.
      * This gives us patterns with "([\d\.]*[\d]+\.[\d]+)" only in places that differ for some matches.
-     * 
+     *
      * @param array $matches
      * @param string $pattern
-     * 
+     *
      * @return array of $matches
      */
     protected function deduplicateCompressionPattern($matches, &$pattern)
     {
       $tmp_matches = $matches;
-      
+
       $first_match = array_shift($tmp_matches);
-      
+
       $differences = array();
-      
+
       foreach ($tmp_matches as $some_match)
       {
         $differences += array_diff_assoc($first_match, $some_match);
       }
-      
+
       $identical = array_diff_key($first_match, $differences);
-      
+
       $prepared_matches = array();
-      
+
       foreach ($matches as $i => $some_match)
       {
         $prepared_matches[self::COMPRESSION_PATTERN_START . implode(self::COMPRESSION_PATTERN_DELIMITER, array_diff_assoc($some_match, $identical))] = $i;
       }
-      
+
       $pattern_parts = explode('([\d\.]*[\d]+\.[\d]+)', $pattern);
-      
+
       foreach ($identical as $position => $value)
       {
         $pattern_parts[$position + 1] = $pattern_parts[$position] . $value . $pattern_parts[$position + 1];
         unset($pattern_parts[$position]);
       }
-      
+
       $pattern = implode('([\d\.]*[\d]+\.[\d]+)', $pattern_parts);
-      
+
       return $prepared_matches;
     }
-    
+
     /**
      * Converts browscap match patterns into preg match patterns.
-     * 
+     *
      * @param string $user_agent
-     * 
+     *
      * @return string
      */
     protected function _pregQuote($user_agent)
     {
       $pattern = preg_quote($user_agent, self::REGEX_DELIMITER);
-      
+
       // the \\x replacement is a fix for "Der gro\xdfe BilderSauger 2.00u" user agent match
-      
+
       return self::REGEX_DELIMITER
           . '^'
           . str_replace(array('\*', '\?', '\\x'), array('.*', '.', '\\\\x'), $pattern)
           . '$'
           . self::REGEX_DELIMITER;
     }
-    
+
     /**
      * Converts preg match patterns back to browscap match patterns.
-     * 
+     *
      * @param string $pattern
      * @param array $matches
-     * 
+     *
      * @return string
      */
     protected function _pregUnQuote($pattern, $matches)
@@ -704,9 +704,9 @@ class Browscap
       // to properly unescape '?' which was changed to '.', I replace '\.' (real dot) with '\?', then change '.' to '?' and then '\?' to '.'.
       $search = array('\\' . self::REGEX_DELIMITER, '\\.', '\\\\', '\\+', '\\[', '\\^', '\\]', '\\$', '\\(', '\\)', '\\{', '\\}', '\\=', '\\!', '\\<', '\\>', '\\|', '\\:', '\\-', '.*', '.', '\\?');
       $replace = array(self::REGEX_DELIMITER, '\\?', '\\', '+', '[', '^', ']', '$', '(', ')', '{', '}', '=', '!', '<', '>', '|', ':', '-', '*', '?', '.');
-      
+
       $result = substr(str_replace($search, $replace, $pattern), 2, -2);
-      
+
       if ($matches)
       {
         foreach ($matches as $one_match)
@@ -715,7 +715,7 @@ class Browscap
           $result = substr_replace($result, $one_match, $num_pos, 4);
         }
       }
-      
+
       return $result;
     }
 
@@ -723,18 +723,18 @@ class Browscap
      * Loads the cache into object's properties
      *
      * @param $cache_file
-     * 
+     *
      * @return boolean
      */
     protected function _loadCache($cache_file)
     {
         require $cache_file;
-        
+
         if (!isset($cache_version) || $cache_version != self::CACHE_FILE_VERSION)
         {
           return false;
         }
-        
+
         $this->_source_version = $source_version;
         $this->_browsers = $browsers;
         $this->_userAgents = $userAgents;
@@ -742,7 +742,7 @@ class Browscap
         $this->_properties = $properties;
 
         $this->_cacheLoaded = true;
-        
+
         return true;
     }
 
@@ -773,9 +773,9 @@ class Browscap
 
     /**
      * Lazy getter for the stream context resource.
-     * 
+     *
      * @param bool $recreate
-     * 
+     *
      * @return resource
      */
     protected function _getStreamContext($recreate = false)
@@ -910,7 +910,7 @@ class Browscap
 
             $strings[] = $key . $value;
         }
-        
+
         return "array(\n" . implode(",\n", $strings) . "\n)";
     }
 
@@ -1023,7 +1023,7 @@ class Browscap
             case false:
                 throw new Exception('Your server can\'t connect to external resources. Please update the file manually.');
         }
-        
+
         return '';
     }
 

--- a/travis.phpunit.xml.dist
+++ b/travis.phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php"
+         verbose="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         colors="false"
+         forceCoversAnnotation="false"
+         strict="false"
+         processIsolation="false">
+    <testsuites>
+        <testsuite name="PHP Browscap Tests">
+            <directory>./tests/phpbrowscap/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/phpbrowscap</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/coverage" title="PHP Coveralls" charset="UTF-8" yui="true" highlight="true" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
Hello,

I changed the duplicate check which was added with version 2.0b from single numbers to numbers with dots to cover complete version numbers.

I also added configuation files for the services on https://scrutinizer-ci.com and https://coveralls.io, and I added PHP 5.5 to the .travis.yml
